### PR TITLE
fix: scope footer render hook to registering panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-03-16
+
+### Fixed
+
+- Footer render hook now scoped to the registering panel, preventing it from rendering on unrelated panels in multi-panel applications
+
 ## [1.0.0] - 2026-03-16
 
 - Initial public release
@@ -14,5 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional footer with configurable office contact information
 - Default favicon and brand logo with automatic fallback
 
-[Unreleased]: https://github.com/NIT-Administrative-Systems/northwestern-filament-theme/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/NIT-Administrative-Systems/northwestern-filament-theme/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/NIT-Administrative-Systems/northwestern-filament-theme/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/NIT-Administrative-Systems/northwestern-filament-theme/releases/tag/v1.0.0

--- a/src/NorthwesternTheme.php
+++ b/src/NorthwesternTheme.php
@@ -9,7 +9,6 @@ use Filament\Contracts\Plugin;
 use Filament\Panel;
 use Filament\Support\Assets\Css;
 use Filament\Support\Facades\FilamentAsset;
-use Filament\Support\Facades\FilamentView;
 use Filament\View\PanelsRenderHook;
 use Northwestern\FilamentTheme\Footer\FooterConfig;
 
@@ -130,7 +129,7 @@ class NorthwesternTheme implements Plugin
         if ($this->footerConfig instanceof FooterConfig) {
             $config = $this->footerConfig;
 
-            FilamentView::registerRenderHook(
+            $panel->renderHook(
                 PanelsRenderHook::BODY_END,
                 fn (): string => $config->isEnabled()
                     ? view('northwestern-filament-theme::footer', ['config' => $config])->render()

--- a/tests/Feature/PluginRegistrationTest.php
+++ b/tests/Feature/PluginRegistrationTest.php
@@ -109,6 +109,27 @@ it('does not override a panel-configured brand logo', function () {
     expect($panel->getBrandLogo())->toBe('https://example.com/custom-logo.svg');
 });
 
+it('registers footer render hook on the panel not globally', function () {
+    $panelWithFooter = app(Panel::class)->id('test-scoped-footer');
+    $panelWithoutFooter = app(Panel::class)->id('test-no-footer-panel');
+
+    $pluginWithFooter = NorthwesternTheme::make()->footer();
+    $pluginWithFooter->register($panelWithFooter);
+    $pluginWithFooter->boot($panelWithFooter);
+
+    $pluginWithoutFooter = NorthwesternTheme::make();
+    $pluginWithoutFooter->register($panelWithoutFooter);
+    $pluginWithoutFooter->boot($panelWithoutFooter);
+
+    $getHooks = fn (Panel $panel) => (new ReflectionProperty($panel, 'renderHooks'))->getValue($panel);
+
+    $hooksWithFooter = $getHooks($panelWithFooter);
+    $hooksWithoutFooter = $getHooks($panelWithoutFooter);
+
+    expect($hooksWithFooter)->toHaveKey(Filament\View\PanelsRenderHook::BODY_END);
+    expect($hooksWithoutFooter)->not->toHaveKey(Filament\View\PanelsRenderHook::BODY_END);
+});
+
 it('renders the footer view with custom office info', function () {
     $config = new FooterConfig(
         officeName: 'Test Office',


### PR DESCRIPTION
Prevents the footer from rendering on panels that did not register the plugin in multi-panel applications.