### PR TITLE
chore: add minimum release age (4320m) for supply-chain security

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict = true
+minimum-release-age=4320

--- a/demo/.npmrc
+++ b/demo/.npmrc
@@ -1,1 +1,2 @@
 engine-strict = true
+minimum-release-age=4320


### PR DESCRIPTION
## Summary

Adds a minimum release age setting so that freshly published package versions must age before they can be installed.

This is a supply-chain security measure that reduces exposure to compromised packages that rely on rapid automated
consumption before detection or takedown.

## Details

For this to work, the project must be using a recent version of its package manager. **Please manually verify what
version is being used** by developers and GitHub Actions.

<sub>This is challenging to automatically detect, since in many cases, there is no version specified or differing
versions between pipelines and developers.</sub>

| Package Manager | Minimum Package Manager Version | Setting | Value |
|---|---|---|---|
| pnpm | v10 | `minimumReleaseAge` in `pnpm-workspace.yaml` | 4320 minutes |
| yarn (Berry) | v4.10 | `npmMinimalAgeGate` in `.yarnrc.yml` | 4320 minutes  |
| npm | v11 | `min-release-age` in `.npmrc` | 4320 minutes |

## Impact

The repository should not experience any significant differences: new versions of packages will not be selected when
running an `update` command until 24 hours have passed. For the most part, updates come from Dependabot, which already
adds a delay.

The major difference is, in cases where you have just released a new version of a package and want to pull it in
as a dependency, an extra step is needed to bypass the age gate:

- pnpm: Add it to the [`minimumReleaseAgeExclude`](https://pnpm.io/settings#minimumreleaseageexclude)
- yarn: Add it to [`npmPreapprovedPackages`](https://yarnpkg.com/configuration/yarnrc#npmPreapprovedPackages)
- npm: There is no supported bypass option; disable the minimum and update the specific package you need.

## References

- https://pnpm.io/settings#minimumreleaseage
- https://yarnpkg.com/configuration/yarnrc
- https://socket.dev/blog/npm-introduces-minimumreleaseage-and-bulk-oidc-configuration